### PR TITLE
Allow services to become suspended

### DIFF
--- a/src/actions/service.js
+++ b/src/actions/service.js
@@ -6,6 +6,12 @@ export default {
     serviceId: PropTypes.string.isRequired,
     keepActiveRoute: PropTypes.bool,
   },
+  setSuspended: {
+    serviceId: PropTypes.string.isRequired,
+  },
+  clearSuspended: {
+    serviceId: PropTypes.string.isRequired,
+  },
   blurActive: {},
   setActiveNext: {},
   setActivePrev: {},

--- a/src/components/services/content/ServiceView.js
+++ b/src/components/services/content/ServiceView.js
@@ -143,11 +143,14 @@ export default @observer class ServiceView extends Component {
                 {service.recipe.id === CUSTOM_WEBSITE_ID && (
                   <WebControlsScreen service={service} />
                 )}
-                <ServiceWebview
-                  service={service}
-                  setWebviewReference={setWebviewReference}
-                  detachService={detachService}
-                />
+                {!service.isSuspended &&
+                  // Removing <webview /> from the DOM kills the process associated with it
+                  <ServiceWebview
+                    service={service}
+                    setWebviewReference={setWebviewReference}
+                    detachService={detachService}
+                  />
+                }
               </>
             )}
           </>

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -24,6 +24,10 @@ export default class Service {
 
   @observable isActive = false; // Is current webview active
 
+  @observable isSuspended = false;
+
+  @observable liveFrom = Date.now(); // timestamp
+
   @observable name = '';
 
   @observable unreadDirectMessageCount = 0;


### PR DESCRIPTION
### Description
1. Add `isSuspended` boolean and `liveFrom` timestamp to the Service model.
2. Add actions to set `isSuspended` and make the service suspended or not.
3. Render the service’s WebView only when `!service.isSuspended`.
4. Add a timer to find stale services and make them suspended if they stale > 5min.

### TODO
- [ ] Use `staleFrom` instead of `liveFrom`.
- [ ] Timing configuration on service-base, e.g. messaging apps should be hold stale for longer, etc.
  - [ ] How long should it take to consider a service stale? Is there any data we can check to define it?
  - [ ] What strategy is considered to be used for messaging services?
- [ ] Ability to turn on and off the suspend feature from the settings screen.

### Motivation and Context
The app becomes laggy when there are too many WebViews’ processes. More likely, some of them shouldn’t be in use. The idea is to kill these processes and free the resources they use.

### How Has This Been Tested?
Install [electron-process-manager](https://www.npmjs.com/package/electron-process-manager) to track how the process is killed for the service that becomes suspended and the WebView associated with it removed.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [ ] My code follows the code style of this project (run `$ yarn lint`).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
